### PR TITLE
Updated backend not connecting error page

### DIFF
--- a/src/commons/application/ApplicationWrapper.tsx
+++ b/src/commons/application/ApplicationWrapper.tsx
@@ -49,8 +49,8 @@ const ApplicationWrapper: React.FC = () => {
       <div className={classNames('NoPage', Classes.DARK)}>
         <NonIdealState
           icon={IconNames.WRENCH}
-          title="Under maintenance"
-          description="The Source Academy is currently undergoing maintenance. Please try again later."
+          title="Problem connecting to backend"
+          description="Contact the course teachers so they can resolve the issue"
         />
       </div>
     );


### PR DESCRIPTION
Before the error page students where brought to when the backend was down talked about maintenance, making it sound intentional, and telling them to try again later. As the backend might be down accedentally the message was changed to ask students to instead alert the teachers.